### PR TITLE
Update country mapping

### DIFF
--- a/force-app/pdl-handler/classes/KafkaPDLHandler2.cls
+++ b/force-app/pdl-handler/classes/KafkaPDLHandler2.cls
@@ -45,7 +45,8 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
                     setMessageError(errorMsg, msg, KafkaMessageService.STATUS_ERROR);
                     logger.error(
                         'Error creatign Person__c from PDL Kafka message. ' +
-                        '\n ' + e.getMessage() +
+                        '\n ' +
+                        e.getMessage() +
                         '\n Kafka key reference: ' +
                         msg.CRM_Key__c,
                         null,
@@ -54,7 +55,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
                 } catch (Exception e) {
                     String errorMsg = e.getTypeName() + ': ' + e.getMessage() + ' (' + e.getLineNumber() + ')';
                     setMessageError(errorMsg, msg);
-                    if(msg.CRM_Status__c == KafkaMessageService.STATUS_ERROR){
+                    if (msg.CRM_Status__c == KafkaMessageService.STATUS_ERROR) {
                         logger.error(
                             'Error creatign Person__c from PDL Kafka message. ' +
                             '\n Kafka key reference: ' +
@@ -62,7 +63,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
                             null,
                             CRM_ApplicationDomain.domain.NKS
                         );
-                    }else if(msg.CRM_Status__c == KafkaMessageService.STATUS_WARNING){
+                    } else if (msg.CRM_Status__c == KafkaMessageService.STATUS_WARNING) {
                         logger.warning(
                             'Warning creatign Person__c from PDL Kafka message. ' +
                             '\n Kafka key reference: ' +
@@ -90,7 +91,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
                     errorMsg += ' * ' + error.getMessage();
                 }
                 setMessageError(errorMsg, messageList[i]);
-                if(messageList[i].CRM_Status__c == KafkaMessageService.STATUS_ERROR){
+                if (messageList[i].CRM_Status__c == KafkaMessageService.STATUS_ERROR) {
                     logger.error(
                         'Error updating Person__c.' +
                         '\n Kafka key reference: ' +
@@ -98,7 +99,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
                         null,
                         CRM_ApplicationDomain.domain.NKS
                     );
-                }else if(messageList[i].CRM_Status__c == KafkaMessageService.STATUS_WARNING){
+                } else if (messageList[i].CRM_Status__c == KafkaMessageService.STATUS_WARNING) {
                     logger.warning(
                         'Warning updating Person__c.' +
                         '\n Kafka key reference: ' +
@@ -126,25 +127,25 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
         Set<String> personTombSet = new Set<String>();
         List<String> personIdList = new List<String>();
         List<Datetime> updatedList = new List<Datetime>();
-        Map<String, Datetime> updatedMap = new Map<String,Datetime>();
+        Map<String, Datetime> updatedMap = new Map<String, Datetime>();
         Set<String> split = new Set<String>();
 
-        for(KafkaMessage__c msg : messages){
+        for (KafkaMessage__c msg : messages) {
             Key k = getKeyFromBase64(msg.CRM_Key__c);
             //Lists of key values wich match order of kafka messages
             idList.add(k.aktoer_id);
             tombList.add(k.tombstone);
             //A Set of idents with tombstones from kafka messages
-            if(k.tombstone == true){
+            if (k.tombstone == true) {
                 tombSet.add(k.aktoer_id);
             }
         }
-        for(Person__c p : [
+        for (Person__c p : [
             SELECT INT_ActorId__c, INT_LastUpdatedFromPDL__c, INT_IsHasTombstone__c
             FROM Person__c
             WHERE INT_ActorId__c IN :idList
-        ]){
-            if(p.INT_IsHasTombstone__c){
+        ]) {
+            if (p.INT_IsHasTombstone__c) {
                 //A Set of idents wich already has tombstones
                 personTombSet.add(p.INT_ActorId__c);
             }
@@ -153,13 +154,13 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
             //A List of Update Datetime values (same order as personIdList)
             updatedList.add(p.INT_LastUpdatedFromPDL__c);
         }
-        for(Integer i = 0; i < personIdList.size(); i++){
+        for (Integer i = 0; i < personIdList.size(); i++) {
             System.debug('for: ' + personIdList[i]);
-            if(!personTombSet.contains(personIdList[i]) && !split.contains(personIdList[i])){
-                if(!updatedMap.containsKey(personIdList[i])){
+            if (!personTombSet.contains(personIdList[i]) && !split.contains(personIdList[i])) {
+                if (!updatedMap.containsKey(personIdList[i])) {
                     //A Map with ident as a key and LastUpdate as a value for existing persons
-                    updatedMap.put(personIdList[i],updatedList[i]);
-                }else{
+                    updatedMap.put(personIdList[i], updatedList[i]);
+                } else {
                     //in case if there are several persons with same actorId making a list for it
                     split.add(personIdList[i]);
                     updatedMap.remove(personIdList[i]);
@@ -168,21 +169,37 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
         }
         existingActors = updatedMap.keySet();
 
-        for(Integer i = 0; i < messages.size(); i++){
-            if(split.contains(idList[i])){
+        for (Integer i = 0; i < messages.size(); i++) {
+            if (split.contains(idList[i])) {
                 //when a few person records with same actor id exists
-                setMessageError('There exists more than one records for Id.(split/merge)', messages[i], KafkaMessageService.STATUS_ERROR);
-            } else if(personTombSet.contains(idList[i])){
+                setMessageError(
+                    'There exists more than one records for Id.(split/merge)',
+                    messages[i],
+                    KafkaMessageService.STATUS_ERROR
+                );
+            } else if (personTombSet.contains(idList[i])) {
                 //when person already exists and has tombstone
-                setMessageError('Trying update Tombstone.',messages[i],KafkaMessageService.STATUS_WARNING);
-            } else if(updatedMap.containsKey(idList[i]) && (messages[i].createdDate < updatedMap.get(idList[i]))){
+                setMessageError('Trying update Tombstone.', messages[i], KafkaMessageService.STATUS_WARNING);
+            } else if (updatedMap.containsKey(idList[i]) && (messages[i].createdDate < updatedMap.get(idList[i]))) {
                 //when person exists and has more recent update
-                setMessageError('Trying update a newer record. Skip update.', messages[i], KafkaMessageService.STATUS_WARNING);
-            } else if(!tombList[i] && tombSet.contains(idList[i])){
+                setMessageError(
+                    'Trying update a newer record. Skip update.',
+                    messages[i],
+                    KafkaMessageService.STATUS_WARNING
+                );
+            } else if (!tombList[i] && tombSet.contains(idList[i])) {
                 //when there is update and tombstone messages for same person in the list
-                setMessageError('There is a Tombstone message for person. Skip update.', messages[i],KafkaMessageService.STATUS_WARNING);
-            } else if(!updatedMap.containsKey(idList[i]) && tombList[i]){
-                setMessageError('Trying insert Tombstone. Skip insert.', messages[i],KafkaMessageService.STATUS_PROCESSED);
+                setMessageError(
+                    'There is a Tombstone message for person. Skip update.',
+                    messages[i],
+                    KafkaMessageService.STATUS_WARNING
+                );
+            } else if (!updatedMap.containsKey(idList[i]) && tombList[i]) {
+                setMessageError(
+                    'Trying insert Tombstone. Skip insert.',
+                    messages[i],
+                    KafkaMessageService.STATUS_PROCESSED
+                );
             }
         }
     }
@@ -582,9 +599,9 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
      * @return country in English
      */
     @TestVisible
-    private static String getCountryNameFromIso(String isoCode) {
+    private String getCountryNameFromIso(String isoCode) {
         Common_Code__c country = getCountryFromIso(isoCode);
-        return country == null ? null : country.Name;
+        return country == null ? isoCode : country.Name;
     }
 
     /**
@@ -593,7 +610,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
      * @return country in English
      */
     @TestVisible
-    private static Id getCountryIdFromIso(String isoCode) {
+    private Id getCountryIdFromIso(String isoCode) {
         Common_Code__c country = getCountryFromIso(isoCode);
         return country == null ? null : country.Id;
     }
@@ -604,14 +621,21 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
      * @return country in English
      */
     @TestVisible
-    private static Common_Code__c getCountryFromIso(String isoCode) {
-        if (isoCode == null || isoCode == '') {
-            return null;
-        } else if (ISO_MAP.containsKey(isoCode)) {
+    private Common_Code__c getCountryFromIso(String isoCode) {
+        if (ISO_MAP.containsKey(isoCode)) {
             return ISO_MAP.get(isoCode);
-        } else {
-            throw new isoCodeNotFoundException('No country was found for the ISO code \'' + isoCode + '\'.');
         }
+
+        if (String.isNotBlank(isoCode)) {
+            logger.error(
+                'Error getting country from ISO Code.' +
+                '\n ISO Code: ' +
+                isoCode,
+                null,
+                CRM_ApplicationDomain.domain.NKS
+            );
+        }
+        return null;
     }
 
     /**
@@ -620,7 +644,7 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
      * @return country names joined with ';'
      */
     @TestVisible
-    private static String crateCitizenshipString(List<String> citizenships) {
+    private String crateCitizenshipString(List<String> citizenships) {
         String citizenshipReturnString = '';
         for (String citizenship : citizenships) {
             citizenshipReturnString = citizenshipReturnString + (getCountryNameFromIso(citizenship)) + ';';
@@ -665,26 +689,25 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
      * if the list does not include valid idents - throwing exception
      */
     @TestVisible
-    private static void setName(KafkaPerson2 kfkPerson, Person__c person){
+    private static void setName(KafkaPerson2 kfkPerson, Person__c person) {
         List<PDL_IdentInformasjon> identer = new List<PDL_IdentInformasjon>(kfkPerson.identer);
         String flkId;
         String npId;
-        for(PDL_IdentInformasjon ident : identer){
-            if(ident.historisk == false){
-                switch on ident.gruppe{
-                    when FOLKEREGISTERIDENT{
+        for (PDL_IdentInformasjon ident : identer) {
+            if (ident.historisk == false) {
+                switch on ident.gruppe {
+                    when FOLKEREGISTERIDENT {
                         flkId = ident.ident;
                     }
-                    when NPID{
+                    when NPID {
                         npId = ident.ident;
                     }
                 }
             }
         }
-        person.Name = (String.isNotBlank(flkId)) ? flkId : (
-            (String.isNotBlank(npId) ? npId : null)
-        );
-        if(String.isBlank(person.Name)) throw new PdlIdentException('Not able to set any person idents from Kafka');
+        person.Name = (String.isNotBlank(flkId)) ? flkId : ((String.isNotBlank(npId) ? npId : null));
+        if (String.isBlank(person.Name))
+            throw new PdlIdentException('Not able to set any person idents from Kafka');
     }
 
     /**
@@ -807,7 +830,9 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
         }
 
         //Set field value to false
-        for (String boolField : new List<String>{ 'INT_IsDeceased__c', 'INT_IsNavEmployee__c', 'INT_KRR_Reservation__c' }) {
+        for (
+            String boolField : new List<String>{ 'INT_IsDeceased__c', 'INT_IsNavEmployee__c', 'INT_KRR_Reservation__c' }
+        ) {
             person.put(boolField, false);
         }
     }
@@ -844,9 +869,6 @@ public without sharing class KafkaPDLHandler2 implements IKafkaMessageConsumer {
     }
 
     public class PdlMissingEntryException extends Exception {
-    }
-
-    public class IsoCodeNotFoundException extends Exception {
     }
 
     public class PdlIdentException extends Exception {

--- a/force-app/pdl-handler/classes/KafkaPDLHandler2Test.cls
+++ b/force-app/pdl-handler/classes/KafkaPDLHandler2Test.cls
@@ -47,42 +47,32 @@ private with sharing class KafkaPDLHandler2Test {
     @IsTest
     static void getCountryFromIsoReturnNull() {
         Test.startTest();
-        System.assertEquals(null, KafkaPDLHandler2.getCountryFromIso(null), 'Expected null in return');
+        System.assertEquals(null, new KafkaPDLHandler2().getCountryFromIso(null), 'Expected null in return');
         Test.stopTest();
     }
 
     @IsTest
     static void getCountryFromIsoReturnCommonCode() {
         Test.startTest();
-        System.assertNotEquals(null, KafkaPDLHandler2.getCountryFromIso('NOR'), 'Expected null in return');
-        Test.stopTest();
-    }
-
-    @IsTest
-    static void getCountryFromIsoReturnException() {
-        Test.startTest();
-        try {
-            KafkaPDLHandler2.getCountryFromIso('NON-EXISTING');
-            System.assertEquals(true, false, 'Expected an exception to be thrown');
-        } catch (KafkaPDLHandler2.IsoCodeNotFoundException e) {
-            System.assertEquals(true, true, 'Expected to catch IsoCodeNotFoundException');
-        } catch (Exception e) {
-            System.assertEquals(true, false, 'Expected to catch IsoCodeNotFoundException not Exception');
-        }
+        System.assertNotEquals(null, new KafkaPDLHandler2().getCountryFromIso('NOR'), 'Expected null in return');
         Test.stopTest();
     }
 
     @IsTest
     static void getCountryNameFromIso() {
         Test.startTest();
-        System.assertEquals('Norge', KafkaPDLHandler2.getCountryNameFromIso('NOR'), 'Expected Norge in return');
+        System.assertEquals('Norge', new KafkaPDLHandler2().getCountryNameFromIso('NOR'), 'Expected Norge in return');
         Test.stopTest();
     }
 
     @IsTest
     static void getCountrySfIdFromIso() {
         Test.startTest();
-        System.assertNotEquals(null, KafkaPDLHandler2.getCountryIdFromIso('NOR'), 'Did not expected null in return');
+        System.assertNotEquals(
+            null,
+            new KafkaPDLHandler2().getCountryIdFromIso('NOR'),
+            'Did not expected null in return'
+        );
         Test.stopTest();
     }
 
@@ -91,7 +81,7 @@ private with sharing class KafkaPDLHandler2Test {
         Test.startTest();
         System.assertEquals(
             'Norge;India',
-            KafkaPDLHandler2.crateCitizenshipString(new List<String>{ 'NOR', 'IND' }),
+            new KafkaPDLHandler2().crateCitizenshipString(new List<String>{ 'NOR', 'IND' }),
             'Expected list with Norge and India'
         );
         Test.stopTest();
@@ -101,7 +91,7 @@ private with sharing class KafkaPDLHandler2Test {
      * TESTS FOR idents *
      *******************************************/
     @isTest
-    static void setNameTest(){
+    static void setNameTest() {
         KafkaPerson2 kPerson = createBaseKafkaPerson('1234567890123');
 
         kPerson.identer.add(new PDL_IdentInformasjon());
@@ -134,7 +124,7 @@ private with sharing class KafkaPDLHandler2Test {
         kPerson.identer[0].historisk = true;
         KafkaPDLHandler2.setName(kPerson, person);
 
-        System.assertEquals('12345678911', person.Name , 'Expected non historisk NPID');
+        System.assertEquals('12345678911', person.Name, 'Expected non historisk NPID');
     }
 
     @IsTest
@@ -555,15 +545,19 @@ private with sharing class KafkaPDLHandler2Test {
             [SELECT COUNT() FROM KafkaMessage__c WHERE CRM_Status__c = :KafkaMessageService.STATUS_PROCESSED]
         );
 
-        Person__c p = [SELECT Id, INT_ActorId__c, INT_fnr__c, Name, INT_IsHasTombstone__c, INT_FirstName__c, INT_LastName__c FROM Person__c LIMIT 1];
+        Person__c p = [
+            SELECT Id, INT_ActorId__c, INT_fnr__c, Name, INT_IsHasTombstone__c, INT_FirstName__c, INT_LastName__c
+            FROM Person__c
+            LIMIT 1
+        ];
 
         // Assert that only tombstone and id fields has values
-        System.assertEquals('1000012345678', p.INT_ActorId__c,'ActorId');
+        System.assertEquals('1000012345678', p.INT_ActorId__c, 'ActorId');
         System.assertEquals('12345678901', p.INT_fnr__c, 'fnr');
         System.assertEquals('12345678901', p.Name, 'Name');
         System.assertEquals(true, p.INT_IsHasTombstone__c, 'Tombstone');
-        System.assertEquals(null, p.INT_FirstName__c,'Firstname');
-        System.assertEquals(null, p.INT_LastName__c,'Lastname');
+        System.assertEquals(null, p.INT_FirstName__c, 'Firstname');
+        System.assertEquals(null, p.INT_LastName__c, 'Lastname');
     }
 
     /********************************

--- a/force-app/pdl-handler/classes/KafkaPDLHandlerTest2.cls
+++ b/force-app/pdl-handler/classes/KafkaPDLHandlerTest2.cls
@@ -47,28 +47,14 @@ public with sharing class KafkaPDLHandlerTest2 {
     @IsTest
     static void getCountryFromIsoReturnNull() {
         Test.startTest();
-        System.assertEquals(null, KafkaPDLHandler2.getCountryFromIso(null), 'Expected null in return');
+        System.assertEquals(null, new KafkaPDLHandler2().getCountryFromIso(null), 'Expected null in return');
         Test.stopTest();
     }
 
     @IsTest
     static void getCountryFromIsoReturnCommonCode() {
         Test.startTest();
-        System.assertNotEquals(null, KafkaPDLHandler2.getCountryFromIso('NOR'), 'Expected null in return');
-        Test.stopTest();
-    }
-
-    @IsTest
-    static void getCountryFromIsoReturnException() {
-        Test.startTest();
-        try {
-            KafkaPDLHandler2.getCountryFromIso('NON-EXISTING');
-            System.assertEquals(true, false, 'Expected an exception to be thrown');
-        } catch (KafkaPDLHandler2.IsoCodeNotFoundException e) {
-            System.assertEquals(true, true, 'Expected to catch IsoCodeNotFoundException');
-        } catch (Exception e) {
-            System.assertEquals(true, false, 'Expected to catch IsoCodeNotFoundException not Exception');
-        }
+        System.assertNotEquals(null, new KafkaPDLHandler2().getCountryFromIso('NOR'), 'Expected null in return');
         Test.stopTest();
     }
 
@@ -805,9 +791,9 @@ public with sharing class KafkaPDLHandlerTest2 {
         );
 
         System.assertEquals(
-            KafkaPDLHandler2.getCountryFromIso(kafkaPerson.innflyttingTilNorge[2].fraflyttingsland) == null
+            new KafkaPDLHandler2().getCountryFromIso(kafkaPerson.innflyttingTilNorge[2].fraflyttingsland) == null
                 ? null
-                : KafkaPDLHandler2.getCountryFromIso(kafkaPerson.innflyttingTilNorge[2].fraflyttingsland).Id,
+                : new KafkaPDLHandler2().getCountryFromIso(kafkaPerson.innflyttingTilNorge[2].fraflyttingsland).Id,
             person.INT_MovedFromCountry__c
         );
         System.assertEquals(kafkaPerson.innflyttingTilNorge[0].fraflyttingsstedIUtlandet, person.INT_MovedFromPlace__c);
@@ -939,7 +925,7 @@ public with sharing class KafkaPDLHandlerTest2 {
         }
 
         System.assertEquals(
-            KafkaPDLHandler2.crateCitizenshipString(kafkaPerson.statsborgerskap),
+            new KafkaPDLHandler2().crateCitizenshipString(kafkaPerson.statsborgerskap),
             person.INT_Citizenships__c
         );
         System.assertEquals(kafkaPerson.sivilstand[0].type.name(), person.INT_MaritalStatus__c);
@@ -959,9 +945,9 @@ public with sharing class KafkaPDLHandlerTest2 {
                 System.assertEquals(tlf.landskode + tlf.nummer, person.INT_Phone2__c);
         }
         System.assertEquals(
-            KafkaPDLHandler2.getCountryFromIso(kafkaPerson.utflyttingFraNorge[0].tilflyttingsland) == null
+            new KafkaPDLHandler2().getCountryFromIso(kafkaPerson.utflyttingFraNorge[0].tilflyttingsland) == null
                 ? null
-                : KafkaPDLHandler2.getCountryFromIso(kafkaPerson.utflyttingFraNorge[0].tilflyttingsland).Id,
+                : new KafkaPDLHandler2().getCountryFromIso(kafkaPerson.utflyttingFraNorge[0].tilflyttingsland).Id,
             person.INT_MovedToCountry__c
         );
         System.assertEquals(kafkaPerson.utflyttingFraNorge[0].tilflyttingsstedIUtlandet, person.INT_MovedToPlace__c);
@@ -1029,12 +1015,15 @@ public with sharing class KafkaPDLHandlerTest2 {
     }
 
     @isTest
-    private static void processMessagesCreateWarningTest(){
+    private static void processMessagesCreateWarningTest() {
         KafkaPerson2 person1 = new KafkaPerson2();
         person1.aktoerId = '1000012345678';
         person1.folkeregisterId = new List<String>{ '20000000000' };
         person1.foedselsdato = new List<String>{ '1966-08-19' };
-        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize('[{"ident":"20000000000"}]', List<PDL_IdentInformasjon>.class);
+        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize(
+            '[{"ident":"20000000000"}]',
+            List<PDL_IdentInformasjon>.class
+        );
 
         KafkaMessage__c kfkMsg = new KafkaMessage__c(
             CRM_Topic__c = 'teamnks.nks-sf-pdl-v3',
@@ -1047,37 +1036,32 @@ public with sharing class KafkaPDLHandlerTest2 {
     }
 
     @isTest
-    private static void processMessagesPdlIdentExceptionTest(){
+    private static void processMessagesPdlIdentExceptionTest() {
         KafkaPerson2 person1 = new KafkaPerson2();
         person1.aktoerId = '1000012345678';
         person1.folkeregisterId = new List<String>{ '20000000000' };
         person1.folkeregisterpersonstatus = new List<String>{ 'bosatt' };
         person1.foedselsdato = new List<String>{ '1966-08-19' };
-        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize('[{"ident":"", "gruppe":"FOLKEREGISTERIDENT"}]', List<PDL_IdentInformasjon>.class);
+        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize(
+            '[{"ident":"", "gruppe":"FOLKEREGISTERIDENT"}]',
+            List<PDL_IdentInformasjon>.class
+        );
 
         person1.navn = new List<PDL_Navn>{ new PDL_Navn() };
         person1.navn[0].etternavn = 'TULLEEFTERNAVN';
 
         person1.bostedsadresse = new KafkaPerson2.Adresser();
-        person1.bostedsadresse.vegadresse = new List<KafkaPerson2.Vegadresse>{
-            new KafkaPerson2.Vegadresse()
-        };
+        person1.bostedsadresse.vegadresse = new List<KafkaPerson2.Vegadresse>{ new KafkaPerson2.Vegadresse() };
         person1.bostedsadresse.matrikkeladresse = new List<KafkaPerson2.Matrikkeladresse>{
             new KafkaPerson2.Matrikkeladresse()
         };
         person1.bostedsadresse.utenlandskAdresse = new List<KafkaPerson2.UtenlandskAdresse>{};
-        person1.bostedsadresse.ukjentBosted = new List<KafkaPerson2.UkjentBosted>{
-            new KafkaPerson2.UkjentBosted()
-        };
+        person1.bostedsadresse.ukjentBosted = new List<KafkaPerson2.UkjentBosted>{ new KafkaPerson2.UkjentBosted() };
         person1.oppholdsadresse = new KafkaPerson2.Adresser();
-        person1.oppholdsadresse.vegadresse = new List<KafkaPerson2.Vegadresse>{
-            new KafkaPerson2.Vegadresse()
-        };
+        person1.oppholdsadresse.vegadresse = new List<KafkaPerson2.Vegadresse>{ new KafkaPerson2.Vegadresse() };
         person1.oppholdsadresse.matrikkeladresse = new List<KafkaPerson2.Matrikkeladresse>{};
         person1.oppholdsadresse.utenlandskAdresse = new List<KafkaPerson2.UtenlandskAdresse>{};
-        person1.oppholdsadresse.ukjentBosted = new List<KafkaPerson2.UkjentBosted>{
-            new KafkaPerson2.UkjentBosted()
-        };
+        person1.oppholdsadresse.ukjentBosted = new List<KafkaPerson2.UkjentBosted>{ new KafkaPerson2.UkjentBosted() };
         person1.folkeregisteridentifikator = new List<PDL_FolkeregisterIdentifikator>();
 
         KafkaMessage__c kfkMsg = new KafkaMessage__c(
@@ -1090,7 +1074,7 @@ public with sharing class KafkaPDLHandlerTest2 {
         System.assertEquals(KafkaMessageService.STATUS_ERROR, kfkMsg.CRM_Status__c);
     }
     @isTest
-    private static void processMessagesCreateError2Test(){
+    private static void processMessagesCreateError2Test() {
         Person__c person = new Person__c();
         person.INT_ActorId__c = '1000012345678';
         person.Name = '20000000000';
@@ -1101,7 +1085,10 @@ public with sharing class KafkaPDLHandlerTest2 {
         person1.aktoerId = '1000012345678';
         person1.folkeregisterId = new List<String>{ '20000000000' };
         person1.foedselsdato = new List<String>{ '1966-08-19' };
-        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize('[{"ident":"20000000000"}]', List<PDL_IdentInformasjon>.class);
+        person1.identer = (List<PDL_IdentInformasjon>) System.JSON.deserialize(
+            '[{"ident":"20000000000"}]',
+            List<PDL_IdentInformasjon>.class
+        );
 
         KafkaMessage__c kfkMsg = new KafkaMessage__c(
             CRM_Topic__c = 'teamnks.nks-sf-pdl-v3',


### PR DESCRIPTION
Fremfor å kaste en exeption dersom landkode ikke mappes riktig så logger vi isteden for en error og legger inn landkode fremfor landnavn. Da unngår vi å blokkere opprettelsen av personen samtidig som det er mulig å utlede land fra landkode.