### PR TITLE
Changed L10 parameter and testclass

### DIFF
--- a/force-app/sms/classes/SMSCalloutService.cls
+++ b/force-app/sms/classes/SMSCalloutService.cls
@@ -1,10 +1,14 @@
 public with sharing class SMSCalloutService extends CRM_ApplicationDomain{
     public static HttpResponse sendSMS(SMS__c sms, CRM_ApplicationDomain.Domain domain, SMS_Config__mdt smsConfig) {
         String recipient = checkRecipient(sms.Recipient__c);
+        
+        /* added 19082022, could be a problem if there is several configurations with the same domain, so the field domain is set to unique */
+        String baseDevName = [SELECT developerName FROM API_Base_Configuration__mdt WHERE domain__c =:String.valueOf(domain)].developerName;
+		String serviceDevName = [SELECT developerName from API_Service_Configuration__mdt WHERE API_Base_Configuration__r.DeveloperName =:baseDevName].developerName;
 
 
         ApiController apiCtrl = new ApiController();
-        apiCtrl.initRequest('SMS_API', 'SEND_SMS');
+        apiCtrl.initRequest(baseDevName, serviceDevName);
         apiCtrl.setBody(formatJSONBody(recipient, sms.Message__c, smsConfig));
         apiCtrl.addHeader('Content-Type', 'application/json');
 

--- a/force-app/sms/classes/SMSCalloutService.cls-meta.xml
+++ b/force-app/sms/classes/SMSCalloutService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>54.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/sms/classes/SMSCalloutServiceTest.cls
+++ b/force-app/sms/classes/SMSCalloutServiceTest.cls
@@ -9,9 +9,9 @@ private class SMSCalloutServiceTest {
             WHERE Domain__c = 'TEST'
         ];
 
-        ApiMock.setTestMock('SEND_SMS', 200, 'OK');
+        ApiMock.setTestMock('SEND_SMS_TEST', 200, 'OK');
         Test.startTest();
-        HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.HOT, smsConfig);
+        HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.TEST, smsConfig);
         Test.stopTest();
 
         System.assertEquals(200, resp.getStatusCode(), 'Error code was not 200');
@@ -26,9 +26,9 @@ private class SMSCalloutServiceTest {
             WHERE Domain__c = 'TEST'
         ];
 
-        ApiMock.setTestMock('SEND_SMS', 400, 'OK');
+        ApiMock.setTestMock('SEND_SMS_TEST', 400, 'OK');
         Test.startTest();
-        HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.HOT, smsConfig);
+        HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.TEST, smsConfig);
         Test.stopTest();
 
         System.assertEquals(400, resp != null ? resp.getStatusCode() : 400, 'Error code was not 400');
@@ -44,11 +44,11 @@ private class SMSCalloutServiceTest {
             WHERE Domain__c = 'TEST'
         ];
 
-        ApiMock.setTestMock('SEND_SMS', 200, 'OK');
+        ApiMock.setTestMock('SEND_SMS_TEST', 200, 'OK');
         Test.startTest();
         Boolean IsCaughtExeption = false;
         try {
-            HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.HOT, smsConfig);
+            HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.TEST, smsConfig);
         } catch (Exception exept) {
             IsCaughtExeption = true;
         }
@@ -65,11 +65,11 @@ private class SMSCalloutServiceTest {
             WHERE Domain__c = 'TEST'
         ];
 
-        ApiMock.setTestMock('SEND_SMS', 200, 'OK');
+        ApiMock.setTestMock('SEND_SMS_TEST', 200, 'OK');
         Test.startTest();
         Boolean IsCaughtExeption = false;
         try {
-            HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.HOT, smsConfig);
+            HttpResponse resp = SMSCalloutService.sendSMS(sms, CRM_ApplicationDomain.Domain.TEST, smsConfig);
         } catch (Exception exept) {
             IsCaughtExeption = true;
         }


### PR DESCRIPTION
Dette er gjort
1. Nytt felt i API base config - Domain, satt til unik
2. Ny innføring, hovedsaklig for at testklassen ikke skal feile i sandboxer - SMS_TEST_API, SEND_SMS_TEST
3. Endret SMS callout service og test class

Ny rutine ved opprettelse av nye team på SMS  må da på plass
1. Opprette named credential med brukernavn/passord
2. API base conifg må opprettes
3. API base service må opprettes

Før dette går ut i produksjon må HOT og AAREG sjekke sine oppføringer. 