### PR TITLE
Update SMSCalloutQueueable.cls

### DIFF
--- a/force-app/sms/classes/SMSCalloutQueueable.cls
+++ b/force-app/sms/classes/SMSCalloutQueueable.cls
@@ -23,6 +23,7 @@ public class SMSCalloutQueueable extends CRM_ApplicationDomain implements Queuea
                 HTTPResponse resp = SMSCalloutService.sendSMS(sms, domain, domainToMetadata.get(sms.Domain__c));
                 if (resp?.getStatusCode() == 200) {
                     smsCopy.Status__c = 'Sent';
+                    smsCopy.Recipient__c = SMSCalloutService.checkRecipient(sms.Recipient__c);
                 } else {
                     smsCopy.Status__c = 'Could not send';
                 }

--- a/force-app/sms/classes/SMSCalloutQueueable.cls
+++ b/force-app/sms/classes/SMSCalloutQueueable.cls
@@ -23,7 +23,7 @@ public class SMSCalloutQueueable extends CRM_ApplicationDomain implements Queuea
                 HTTPResponse resp = SMSCalloutService.sendSMS(sms, domain, domainToMetadata.get(sms.Domain__c));
                 if (resp?.getStatusCode() == 200) {
                     smsCopy.Status__c = 'Sent';
-                    smsCopy.Recipient__c = SMSCalloutService.checkRecipient(sms.Recipient__c);
+                    smsCopy.RecipientFormatted__c = SMSCalloutService.checkRecipient(sms.Recipient__c);
                 } else {
                     smsCopy.Status__c = 'Could not send';
                 }

--- a/force-app/sms/classes/SMSCalloutQueueable.cls
+++ b/force-app/sms/classes/SMSCalloutQueueable.cls
@@ -23,9 +23,9 @@ public class SMSCalloutQueueable extends CRM_ApplicationDomain implements Queuea
                 HTTPResponse resp = SMSCalloutService.sendSMS(sms, domain, domainToMetadata.get(sms.Domain__c));
                 if (resp?.getStatusCode() == 200) {
                     smsCopy.Status__c = 'Sent';
-                    smsCopy.RecipientFormatted__c = SMSCalloutService.checkRecipient(sms.Recipient__c);
                 } else {
                     smsCopy.Status__c = 'Could not send';
+                    smsCopy.RecipientFormatted__c = SMSCalloutService.checkRecipient(sms.Recipient__c);
                 }
             } catch (Exception e) {
                 LoggerUtility logger = new LoggerUtility();

--- a/force-app/sms/layouts/SMS__c-SMS Layout.layout-meta.xml
+++ b/force-app/sms/layouts/SMS__c-SMS Layout.layout-meta.xml
@@ -57,6 +57,10 @@
                 <behavior>Edit</behavior>
                 <field>Recipient__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RecipientFormatted__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/sms/objectTranslations/SMS__c-no/RecipientFormatted__c.fieldTranslation-meta.xml
+++ b/force-app/sms/objectTranslations/SMS__c-no/RecipientFormatted__c.fieldTranslation-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Mottaker formatert</label>
+    <name>RecipientFormatted__c</name>
+</CustomFieldTranslation>

--- a/force-app/sms/objects/SMS__c/fields/RecipientFormatted__c.field-meta.xml
+++ b/force-app/sms/objects/SMS__c/fields/RecipientFormatted__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Recipient__c</fullName>
+    <externalId>false</externalId>
+    <label>Recipient formatted</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/sms/objects/SMS__c/fields/RecipientFormatted__c.field-meta.xml
+++ b/force-app/sms/objects/SMS__c/fields/RecipientFormatted__c.field-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Recipient__c</fullName>
+    <fullName>RecipientFormatted__c</fullName>
     <externalId>false</externalId>
     <label>Recipient formatted</label>
     <length>255</length>


### PR DESCRIPTION
Legger ved hva recipient faktisk blir etter formatering

Testing:
Opprett SMS
- Domain - HOT
- Type Manually created
- Test med ulike recipients som inkluderer tekst og tegn, feks abc +12345678, +4712345678, +12345678, abc 12345678 abc, abcbcbcbcbcbc+12345678...!wedfdf
 
Når sendt, sjekk at RecipientFormatted ser bra ut: +4712345678