### PR TITLE
added 204 status handler

### DIFF
--- a/force-app/krp/classes/KRP_Persons.cls
+++ b/force-app/krp/classes/KRP_Persons.cls
@@ -16,7 +16,7 @@ public inherited sharing class KRP_Persons {
                     ? (KRP_Konto) JSON.deserialize(resp.getBody(), KRP_Konto.class)
                     : null;
             } else if(resp.getStatusCode() == 204){
-                handleNoBankAccount('Kontohaveren har ingen aktiv konto');
+                handleNoBankAccount('Kontohaveren har ingen aktiv konto', resp);
             } else {
                 handleError('Kunne ikke hente bankkontonummer', resp);
             }

--- a/force-app/krp/classes/KRP_Persons.cls
+++ b/force-app/krp/classes/KRP_Persons.cls
@@ -15,6 +15,8 @@ public inherited sharing class KRP_Persons {
                 bankkonto = String.isNotBlank(resp.getBody())
                     ? (KRP_Konto) JSON.deserialize(resp.getBody(), KRP_Konto.class)
                     : null;
+            } else if(resp.getStatusCode() == 204){
+                handleNoBankAccount('Kontohaveren har ingen aktiv konto');
             } else {
                 handleError('Kunne ikke hente bankkontonummer', resp);
             }
@@ -27,6 +29,21 @@ public inherited sharing class KRP_Persons {
         return bankkonto;
     }
 
+    private static void handleNoBankAccount(String message, HttpResponse resp){
+        String uuid;
+        LoggerUtility logger = new LoggerUtility('KRP');
+        String payload =
+            'HTTP Status: ' +
+            String.valueOf(resp.getStatusCode()) +
+            ' - ' +
+            response.getStatus() +
+            '\n';
+        payload += 'Body: \n' + resp.getBody();
+        logger.logMessage(LoggerUtility.LogLevel.Info, null, null, message, payload, null);
+        uuid = logger.peek().UUID__c;
+        logger.publish();
+        throw new KRP_PersonsException(message + ' LoggId: ' + uuid);
+    }
     private static void handleError(String message, HttpResponse resp) {
         String uuid;
         LoggerUtility logger = new LoggerUtility('KRP');

--- a/force-app/krp/classes/KRP_Persons.cls
+++ b/force-app/krp/classes/KRP_Persons.cls
@@ -36,7 +36,7 @@ public inherited sharing class KRP_Persons {
             'HTTP Status: ' +
             String.valueOf(resp.getStatusCode()) +
             ' - ' +
-            response.getStatus() +
+            resp.getStatus() +
             '\n';
         payload += 'Body: \n' + resp.getBody();
         logger.logMessage(LoggerUtility.LogLevel.Info, null, null, message, payload, null);


### PR DESCRIPTION
Når vi får 204 respons fra KRP logger vi dette som http error. Men statusen viser at det finnes ikke konto for person. Endrer dette slik, vi logger de tilfellene som Info.