### PR TITLE
added logic for address removal on Accounts

### DIFF
--- a/force-app/ereg-handler/classes/KafkaEnhetHandler.cls
+++ b/force-app/ereg-handler/classes/KafkaEnhetHandler.cls
@@ -179,26 +179,12 @@ public without sharing class KafkaEnhetHandler implements IKafkaMessageConsumer 
             acc.INT_RegionNumber__c = org.postadresse.kommunenummer != null
                 ? org.postadresse.kommunenummer.left(2)
                 : null;
-        }
-
-        // Optional fields for enheter
-        if (org.forretningsadresse != null) {
-            //If size of address array is 2, add line break and merge values. Ignore values after 2, due to max lines on address fields in Salesforce
-            if (org.forretningsadresse.adresse != null && org.forretningsadresse.adresse.size() >= 2) {
-                acc.ShippingStreet = org.forretningsadresse.adresse[0] + '\n' + org.forretningsadresse.adresse[1];
-            } else if (org.forretningsadresse.adresse != null && org.forretningsadresse.adresse.size() == 1) {
-                acc.ShippingStreet = org.forretningsadresse.adresse[0];
-            } else {
-                acc.ShippingStreet = null;
-            }
-            acc.ShippingPostalCode = org.forretningsadresse.postnummer;
-            acc.ShippingCity = org.forretningsadresse.poststed;
-            acc.ShippingCountry = org.forretningsadresse.land;
-            acc.ShippingState = org.forretningsadresse.kommune;
-            acc.INT_MunicipalityNumber__c = org.forretningsadresse.kommunenummer;
-            acc.INT_RegionNumber__c = org.forretningsadresse.kommunenummer != null
-                ? org.forretningsadresse.kommunenummer.left(2)
-                : null;
+        } else {
+            acc.BillingStreet = null;
+            acc.BillingPostalCode = null;
+            acc.BillingCity = null;
+            acc.BillingCountry = null;
+            acc.BillingState = null;
         }
         // Optional fields for underenheter
         if (org.beliggenhetsadresse != null) {
@@ -218,6 +204,29 @@ public without sharing class KafkaEnhetHandler implements IKafkaMessageConsumer 
             acc.INT_RegionNumber__c = org.beliggenhetsadresse.kommunenummer != null
                 ? org.beliggenhetsadresse.kommunenummer.left(2)
                 : null;
+        } else if (org.forretningsadresse != null) {
+            //If size of address array is 2, add line break and merge values. Ignore values after 2, due to max lines on address fields in Salesforce
+            if (org.forretningsadresse.adresse != null && org.forretningsadresse.adresse.size() >= 2) {
+                acc.ShippingStreet = org.forretningsadresse.adresse[0] + '\n' + org.forretningsadresse.adresse[1];
+            } else if (org.forretningsadresse.adresse != null && org.forretningsadresse.adresse.size() == 1) {
+                acc.ShippingStreet = org.forretningsadresse.adresse[0];
+            } else {
+                acc.ShippingStreet = null;
+            }
+            acc.ShippingPostalCode = org.forretningsadresse.postnummer;
+            acc.ShippingCity = org.forretningsadresse.poststed;
+            acc.ShippingCountry = org.forretningsadresse.land;
+            acc.ShippingState = org.forretningsadresse.kommune;
+            acc.INT_MunicipalityNumber__c = org.forretningsadresse.kommunenummer;
+            acc.INT_RegionNumber__c = org.forretningsadresse.kommunenummer != null
+                ? org.forretningsadresse.kommunenummer.left(2)
+                : null;
+        } else {
+            acc.ShippingStreet = null;
+            acc.ShippingPostalCode = null;
+            acc.ShippingCity = null;
+            acc.ShippingCountry = null;
+            acc.ShippingState = null;
         }
         return acc;
     }

--- a/force-app/ereg-handler/classes/KafkaEnhetHandlerTest.cls
+++ b/force-app/ereg-handler/classes/KafkaEnhetHandlerTest.cls
@@ -79,6 +79,144 @@ public with sharing class KafkaEnhetHandlerTest {
         ];
         System.Assert.areEqual(10, org810034882.NumberOfEmployees, 'Assert that the number of employees is updated');
         System.Assert.areEqual(true, org810034882.INT_HasEmployees__c, 'Assert that the boolean INT_HasEmployees__c is updated');
+
+        Account org920165842BeforeUpdate = [SELECT Name, ShippingCity, ShippingPostalCode, INT_MunicipalityNumber__c, BillingCity  FROM Account WHERE INT_OrganizationNumber__c = '920165842' LIMIT 1];
+        
+        // Insert a new Kafka Message. The value corresponds to the account with org number 920165842. Forretningsadresse has been removed.
+        KafkaMessage__c messageWOAddress = new KafkaMessage__c();
+        messageWOAddress.CRM_Key__c = '920165842#ENHET#190049246';
+        messageWOAddress.CRM_Topic__c = 'public-ereg-cache-org-json';
+        messageWOAddress.CRM_Value__c = 'ewogICJvcmdhbmlzYXNqb25zbnVtbWVyIiA6ICI5MjAxNjU4NDIiLAogICJuYXZuIiA6ICJPU1RFT1BBVCBTQUdQTEFEUyIsCiAgIm9yZ2FuaXNhc2pvbnNmb3JtIiA6IHsKICAgICJrb2RlIiA6ICJFTksiLAogICAgImJlc2tyaXZlbHNlIiA6ICJFbmtlbHRwZXJzb25mb3JldGFrIiwKICAgICJsaW5rcyIgOiBbIF0KICB9LAogICJyZWdpc3RyZXJpbmdzZGF0b0VuaGV0c3JlZ2lzdGVyZXQiIDogIjIwMTctMTItMjIiLAogICJyZWdpc3RyZXJ0SU12YXJlZ2lzdGVyZXQiIDogZmFsc2UsCiAgIm5hZXJpbmdza29kZTEiIDogewogICAgImJlc2tyaXZlbHNlIiA6ICJBbmRyZSBoZWxzZXRqZW5lc3RlciIsCiAgICAia29kZSIgOiAiODYuOTA5IgogIH0sCiAgImFudGFsbEFuc2F0dGUiIDogMCwKICAiaW5zdGl0dXNqb25lbGxTZWt0b3Jrb2RlIiA6IHsKICAgICJrb2RlIiA6ICI4MjAwIiwKICAgICJiZXNrcml2ZWxzZSIgOiAiUGVyc29ubGlnIG7DpnJpbmdzZHJpdmVuZGUiCiAgfSwKICAicmVnaXN0cmVydElGb3JldGFrc3JlZ2lzdGVyZXQiIDogZmFsc2UsCiAgInJlZ2lzdHJlcnRJU3RpZnRlbHNlc3JlZ2lzdGVyZXQiIDogZmFsc2UsCiAgInJlZ2lzdHJlcnRJRnJpdmlsbGlnaGV0c3JlZ2lzdGVyZXQiIDogZmFsc2UsCiAgImtvbmt1cnMiIDogZmFsc2UsCiAgInVuZGVyQXZ2aWtsaW5nIiA6IGZhbHNlLAogICJ1bmRlclR2YW5nc2F2dmlrbGluZ0VsbGVyVHZhbmdzb3BwbG9zbmluZyIgOiBmYWxzZSwKICAibWFhbGZvcm0iIDogIkJva23DpWwiLAogICJsaW5rcyIgOiBbIF0KfQ==';
+        insert messageWOAddress;
+
+        // Run method explicitly because we cannot rely on the queuable job again in the test context (only one start/stoptest block is allowed)
+        new KafkaEnhetHandler().processMessages(new List<KafkaMessage__c>{ messageWOAddress });
+
+        Account org920165842AfterUpdate = [SELECT Name, ShippingCity, ShippingPostalCode, INT_MunicipalityNumber__c  FROM Account WHERE INT_OrganizationNumber__c = '920165842' LIMIT 1];
+        System.assertEquals(
+            org920165842AfterUpdate.Name,
+            org920165842BeforeUpdate.Name,
+            'Assert that the account name has not been updated'
+        );
+        System.assertEquals(
+            org920165842AfterUpdate.INT_MunicipalityNumber__c,
+            org920165842BeforeUpdate.INT_MunicipalityNumber__c,
+            'Assert that the INT_MunicipalityNumber__c has not been updated'
+        );
+        System.assertEquals(
+            '0857',
+            org920165842BeforeUpdate.ShippingPostalCode,
+            'Assert that the ShippingCity is 0857 before update'
+        );
+        System.assertEquals(
+            'OSLO',
+            org920165842BeforeUpdate.ShippingCity,
+            'Assert that the ShippingCity is OSLO before update'
+        );
+        System.assertEquals(
+            null,
+            org920165842AfterUpdate.ShippingCity,
+            'Assert that the ShippingCity is null after update'
+        );
+        System.assertEquals(
+            null,
+            org920165842AfterUpdate.ShippingPostalCode,
+            'Assert that the ShippingPostalCode is null after update'
+        );
+
+        // Insert a new Kafka Message. The value corresponds to the account with org number 920165842. Forretningsadresse and beliggenhetsadresse has been added and changed.
+        KafkaMessage__c messageW2Address = new KafkaMessage__c();
+        messageW2Address.CRM_Key__c = '920165842#ENHET#190049246';
+        messageW2Address.CRM_Topic__c = 'public-ereg-cache-org-json';
+        messageW2Address.CRM_Value__c = 'ewogICJvcmdhbmlzYXNqb25zbnVtbWVyIiA6ICI5MjAxNjU4NDIiLAogICJuYXZuIiA6ICJPU1RFT1BBVCBTQUdQTEFEUyIsCiAgIm9yZ2FuaXNhc2pvbnNmb3JtIiA6IHsKICAgICJrb2RlIiA6ICJFTksiLAogICAgImJlc2tyaXZlbHNlIiA6ICJFbmtlbHRwZXJzb25mb3JldGFrIiwKICAgICJsaW5rcyIgOiBbIF0KICB9LAogICJyZWdpc3RyZXJpbmdzZGF0b0VuaGV0c3JlZ2lzdGVyZXQiIDogIjIwMTctMTItMjIiLAogICJyZWdpc3RyZXJ0SU12YXJlZ2lzdGVyZXQiIDogZmFsc2UsCiAgIm5hZXJpbmdza29kZTEiIDogewogICAgImJlc2tyaXZlbHNlIiA6ICJBbmRyZSBoZWxzZXRqZW5lc3RlciIsCiAgICAia29kZSIgOiAiODYuOTA5IgogIH0sCiAgImFudGFsbEFuc2F0dGUiIDogMCwKICAiZm9ycmV0bmluZ3NhZHJlc3NlIiA6IHsKICAgICJsYW5kIiA6ICJOb3JnZSIsCiAgICAibGFuZGtvZGUiIDogIk5PIiwKICAgICJwb3N0bnVtbWVyIiA6ICIwODU3IiwKICAgICJwb3N0c3RlZCIgOiAiT1NMTyIsCiAgICAiYWRyZXNzZSIgOiBbICJTb2duc3ZlaWVuIDEwMkwiIF0sCiAgICAia29tbXVuZSIgOiAiT1NMTyIsCiAgICAia29tbXVuZW51bW1lciIgOiAiMDMwMSIKICB9LAogICJiZWxpZ2dlbmhldHNhZHJlc3NlIiA6IHsKICAgICJsYW5kIiA6ICJOb3JnZSIsCiAgICAibGFuZGtvZGUiIDogIk5PIiwKICAgICJwb3N0bnVtbWVyIiA6ICI4MDAxIiwKICAgICJwb3N0c3RlZCIgOiAiQk9Ew5giLAogICAgImFkcmVzc2UiIDogWyAiU29nbnN2ZWllbiAxMDJMIiBdLAogICAgImtvbW11bmUiIDogIkJPRMOYIiwKICAgICJrb21tdW5lbnVtbWVyIiA6ICIwMzAxIgogIH0sCiAgImluc3RpdHVzam9uZWxsU2VrdG9ya29kZSIgOiB7CiAgICAia29kZSIgOiAiODIwMCIsCiAgICAiYmVza3JpdmVsc2UiIDogIlBlcnNvbmxpZyBuw6ZyaW5nc2RyaXZlbmRlIgogIH0sCiAgInJlZ2lzdHJlcnRJRm9yZXRha3NyZWdpc3RlcmV0IiA6IGZhbHNlLAogICJyZWdpc3RyZXJ0SVN0aWZ0ZWxzZXNyZWdpc3RlcmV0IiA6IGZhbHNlLAogICJyZWdpc3RyZXJ0SUZyaXZpbGxpZ2hldHNyZWdpc3RlcmV0IiA6IGZhbHNlLAogICJrb25rdXJzIiA6IGZhbHNlLAogICJ1bmRlckF2dmlrbGluZyIgOiBmYWxzZSwKICAidW5kZXJUdmFuZ3NhdnZpa2xpbmdFbGxlclR2YW5nc29wcGxvc25pbmciIDogZmFsc2UsCiAgIm1hYWxmb3JtIiA6ICJCb2ttw6VsIiwKICAibGlua3MiIDogWyBdCn0=';
+        insert messageW2Address;
+
+        // Run method explicitly because we cannot rely on the queuable job again in the test context (only one start/stoptest block is allowed)
+        new KafkaEnhetHandler().processMessages(new List<KafkaMessage__c>{ messageW2Address });
+
+        Account org920165842AfterUpdate2 = [SELECT Name, ShippingCity, ShippingPostalCode, INT_MunicipalityNumber__c  FROM Account WHERE INT_OrganizationNumber__c = '920165842' LIMIT 1];
+        System.assertEquals(
+            org920165842AfterUpdate2.Name,
+            org920165842BeforeUpdate.Name,
+            'Assert that the account name has not been updated'
+        );
+        System.assertEquals(
+            org920165842AfterUpdate2.INT_MunicipalityNumber__c,
+            org920165842BeforeUpdate.INT_MunicipalityNumber__c,
+            'Assert that the INT_MunicipalityNumber__c has not been updated'
+        );
+        System.assertEquals(
+            '0857',
+            org920165842BeforeUpdate.ShippingPostalCode,
+            'Assert that the ShippingCity is 0857 before update'
+        );
+        System.assertEquals(
+            'OSLO',
+            org920165842BeforeUpdate.ShippingCity,
+            'Assert that the ShippingCity is OSLO before update'
+        );
+        System.assertEquals(
+            'BODØ',
+            org920165842AfterUpdate2.ShippingCity,
+            'Assert that the ShippingCity is BODØ after update'
+        );
+        System.assertEquals(
+            '8001',
+            org920165842AfterUpdate2.ShippingPostalCode,
+            'Assert that the ShippingPostalCode is 8001 after update'
+        );
+
+        // Insert a new Kafka Message. The value corresponds to the account with org number 920165842. Beliggenhetsadresse has been changed and postadresse added.
+        KafkaMessage__c messageW3Address = new KafkaMessage__c();
+        messageW3Address.CRM_Key__c = '920165842#ENHET#190049246';
+        messageW3Address.CRM_Topic__c = 'public-ereg-cache-org-json';
+        messageW3Address.CRM_Value__c = 'ewogICJvcmdhbmlzYXNqb25zbnVtbWVyIiA6ICI5MjAxNjU4NDIiLAogICJuYXZuIiA6ICJPU1RFT1BBVCBTQUdQTEFEUyIsCiAgIm9yZ2FuaXNhc2pvbnNmb3JtIiA6IHsKICAgICJrb2RlIiA6ICJFTksiLAogICAgImJlc2tyaXZlbHNlIiA6ICJFbmtlbHRwZXJzb25mb3JldGFrIiwKICAgICJsaW5rcyIgOiBbIF0KICB9LAogICJyZWdpc3RyZXJpbmdzZGF0b0VuaGV0c3JlZ2lzdGVyZXQiIDogIjIwMTctMTItMjIiLAogICJyZWdpc3RyZXJ0SU12YXJlZ2lzdGVyZXQiIDogZmFsc2UsCiAgIm5hZXJpbmdza29kZTEiIDogewogICAgImJlc2tyaXZlbHNlIiA6ICJBbmRyZSBoZWxzZXRqZW5lc3RlciIsCiAgICAia29kZSIgOiAiODYuOTA5IgogIH0sCiAgImFudGFsbEFuc2F0dGUiIDogMCwKICAiZm9ycmV0bmluZ3NhZHJlc3NlIiA6IHsKICAgICJsYW5kIiA6ICJOb3JnZSIsCiAgICAibGFuZGtvZGUiIDogIk5PIiwKICAgICJwb3N0bnVtbWVyIiA6ICIwODU3IiwKICAgICJwb3N0c3RlZCIgOiAiT1NMTyIsCiAgICAiYWRyZXNzZSIgOiBbICJTb2duc3ZlaWVuIDEwMkwiIF0sCiAgICAia29tbXVuZSIgOiAiT1NMTyIsCiAgICAia29tbXVuZW51bW1lciIgOiAiMDMwMiIKICB9LAogICJiZWxpZ2dlbmhldHNhZHJlc3NlIiA6IHsKICAgICJsYW5kIiA6ICJOb3JnZSIsCiAgICAibGFuZGtvZGUiIDogIk5PIiwKICAgICJwb3N0bnVtbWVyIiA6ICI4MDAxIiwKICAgICJwb3N0c3RlZCIgOiAiQk9Ew5giLAogICAgImFkcmVzc2UiIDogWyAiU29nbnN2ZWllbiAxMDJMIiBdLAogICAgImtvbW11bmUiIDogIkJPRMOYIiwKICAgICJrb21tdW5lbnVtbWVyIiA6ICIwMzAxIgogIH0sCiJwb3N0YWRyZXNzZSIgOiB7CiAgICAibGFuZCIgOiAiTm9yZ2UiLAogICAgImxhbmRrb2RlIiA6ICJOTyIsCiAgICAicG9zdG51bW1lciIgOiAiMTIyMSIsCiAgICAicG9zdHN0ZWQiIDogIkZSRURSSUtTVEFEIiwKICAgICJhZHJlc3NlIiA6IFsgIlNvZ25zdmVpZW4gMTAyTCIgXSwKICAgICJrb21tdW5lIiA6ICJGUkVEUklLU1RBRCIsCiAgICAia29tbXVuZW51bW1lciIgOiAiMTIyMSIKICB9LAogICJpbnN0aXR1c2pvbmVsbFNla3RvcmtvZGUiIDogewogICAgImtvZGUiIDogIjgyMDAiLAogICAgImJlc2tyaXZlbHNlIiA6ICJQZXJzb25saWcgbsOmcmluZ3Nkcml2ZW5kZSIKICB9LAogICJyZWdpc3RyZXJ0SUZvcmV0YWtzcmVnaXN0ZXJldCIgOiBmYWxzZSwKICAicmVnaXN0cmVydElTdGlmdGVsc2VzcmVnaXN0ZXJldCIgOiBmYWxzZSwKICAicmVnaXN0cmVydElGcml2aWxsaWdoZXRzcmVnaXN0ZXJldCIgOiBmYWxzZSwKICAia29ua3VycyIgOiBmYWxzZSwKICAidW5kZXJBdnZpa2xpbmciIDogZmFsc2UsCiAgInVuZGVyVHZhbmdzYXZ2aWtsaW5nRWxsZXJUdmFuZ3NvcHBsb3NuaW5nIiA6IGZhbHNlLAogICJtYWFsZm9ybSIgOiAiQm9rbcOlbCIsCiAgImxpbmtzIiA6IFsgXQp9';
+        insert messageW3Address;
+
+        // Run method explicitly because we cannot rely on the queuable job again in the test context (only one start/stoptest block is allowed)
+        new KafkaEnhetHandler().processMessages(new List<KafkaMessage__c>{ messageW3Address });
+
+        Account org920165842AfterUpdate3 = [SELECT Name, ShippingCity, ShippingPostalCode, INT_MunicipalityNumber__c, BillingCity  FROM Account WHERE INT_OrganizationNumber__c = '920165842' LIMIT 1];
+        System.assertEquals(
+            org920165842AfterUpdate3.Name,
+            org920165842AfterUpdate2.Name,
+            'Assert that the account name has not been updated'
+        );
+        System.assertEquals(
+            org920165842AfterUpdate3.INT_MunicipalityNumber__c,
+            org920165842AfterUpdate2.INT_MunicipalityNumber__c,
+            'Assert that the INT_MunicipalityNumber__c has not been updated'
+        );
+        System.assertEquals(
+            '0857',
+            org920165842BeforeUpdate.ShippingPostalCode,
+            'Assert that the ShippingCity is 0857 before update'
+        );
+        System.assertEquals(
+            'OSLO',
+            org920165842BeforeUpdate.ShippingCity,
+            'Assert that the ShippingCity is OSLO before update'
+        );
+        System.assertEquals(
+            'BODØ',
+            org920165842AfterUpdate3.ShippingCity,
+            'Assert that the ShippingCity is BODØ after update'
+        );
+        System.assertEquals(
+            '8001',
+            org920165842AfterUpdate3.ShippingPostalCode,
+            'Assert that the ShippingPostalCode is 8001 after update'
+        );
+        System.assertEquals(
+            null,
+            org920165842BeforeUpdate.BillingCity,
+            'Assert that the BillingCity is null before update'
+        );
+        System.assertEquals(
+            'FREDRIKSTAD',
+            org920165842AfterUpdate3.BillingCity,
+            'Assert that the BillingCity is FREDRIKSTAD after update'
+        );
     }
 
     @IsTest


### PR DESCRIPTION
Purpose of change is to handle removing of address in ereg- until now when both for eks. postadresse and forretningsadresse were filled in ereg and afterwards Employer removed one of those addresses in ereg, Account in salesforce was not updated (the address was not removed). Added logic now to handle removal of addresses.